### PR TITLE
Chatページ用のLayoutを作成

### DIFF
--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,4 +1,3 @@
-import './globals.css';
 import { Noto_Sans_JP } from 'next/font/google';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
@@ -6,11 +5,11 @@ import type { Metadata } from 'next';
 const font = Noto_Sans_JP({ weight: '400', style: 'normal', subsets: ['cyrillic'] });
 
 export const metadata: Metadata = {
-  title: 'AI Cat🐱',
-  description: 'ねこのAIとお話しよう🐱',
+  title: 'AI Cat もこちゃん🐱',
+  description: 'ねこのAI（もこちゃん）とお話しよう🐱',
 }
 
-const RootLayout = ({ children }: { children: ReactNode }) => {
+const ChatLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ja">
       <body className={font.className}>
@@ -20,4 +19,4 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
   )
 };
 
-export default RootLayout;
+export default ChatLayout;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,9 +1,28 @@
 import { Chat } from '@/components/Chat';
 
+const chatMessages = [
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' } as const,
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'} as const,
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' } as const,
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'} as const,
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' } as const,
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'} as const,
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' } as const,
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！一番下のメッセージだにゃ！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'} as const,
+];
+
 const ChatPage = () => {
   return (
     <div>
-      <Chat />
+      <Chat chatMessages={chatMessages} />
     </div>
   );
 };

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,4 +1,5 @@
 import { Chat } from '@/components/Chat';
+import {ChatContentLayout} from "@/components/ChatContentLayout";
 
 const chatMessages = [
   { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' } as const,
@@ -21,9 +22,9 @@ const chatMessages = [
 
 const ChatPage = () => {
   return (
-    <div>
+    <ChatContentLayout>
       <Chat chatMessages={chatMessages} />
-    </div>
+    </ChatContentLayout>
   );
 };
 

--- a/src/components/CatChatMessage.tsx
+++ b/src/components/CatChatMessage.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+type Props = {
+  message: string;
+  avatarUrl: string;
+  name: string;
+};
+export const CatChatMessage: FC<Props> = ({ message, avatarUrl, name }) => {
+  return (
+    <div className="chat-message">
+      <div className="flex items-end">
+        <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+          <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-100">{message}</span>
+          </div>
+        </div>
+        <img
+          src={avatarUrl}
+          alt={name} className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+      </div>
+    </div>
+
+  );
+};

--- a/src/components/CatChatMessage.tsx
+++ b/src/components/CatChatMessage.tsx
@@ -10,7 +10,7 @@ export const CatChatMessage: FC<Props> = ({ message, avatarUrl, name }) => {
     <div className="chat-message">
       <div className="flex items-end">
         <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-          <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-100">{message}</span>
+          <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-white">{message}</span>
           </div>
         </div>
         <img

--- a/src/components/CatChatMessage.tsx
+++ b/src/components/CatChatMessage.tsx
@@ -18,6 +18,5 @@ export const CatChatMessage: FC<Props> = ({ message, avatarUrl, name }) => {
           alt={name} className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
       </div>
     </div>
-
   );
 };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -2,14 +2,64 @@
 
 import type { FC, FormEvent } from 'react';
 import {Footer} from "@/components/Footer";
+import {UserChatMessage} from "@/components/UserChatMessage";
+import {CatChatMessage} from "@/components/CatChatMessage";
 
-export const Chat: FC = () => {
+type ChatMessage = {
+  role: 'user' | 'cat';
+  name: string;
+  message: string;
+  avatarUrl: string;
+};
+
+type ChatMessages = ChatMessage[];
+
+const chatMessages: ChatMessages = [
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
+  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
+  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
+];
+
+type Props = {
+  chatMessages: ChatMessages;
+};
+
+export const Chat: FC<Props> = ({ chatMessages }) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
   };
 
   return (
-    <div className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen">
+    <div className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen bg-white">
       <div className="flex sm:items-center justify-between py-3 border-b-2 border-gray-200">
         <div className="relative flex items-center space-x-4">
           <div className="relative">
@@ -28,138 +78,15 @@ export const Chat: FC = () => {
           {/*Buttonとかを並べるエリア*/}
         </div>
       </div>
-      <div id="messages"
-           className="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch">
-        {/*（自分のメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end justify-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
-              </div>
-            </div>
-            <img
-              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（相手からのメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
-              </div>
-            </div>
-            <img
-              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（自分のメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end justify-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
-              </div>
-            </div>
-            <img
-              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（相手からのメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
-              </div>
-            </div>
-            <img
-              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（自分のメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end justify-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
-              </div>
-            </div>
-            <img
-              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（相手からのメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
-              </div>
-            </div>
-            <img
-              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（自分のメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end justify-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
-              </div>
-            </div>
-            <img
-              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（相手からのメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
-              </div>
-            </div>
-            <img
-              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（自分のメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end justify-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
-              </div>
-            </div>
-            <img
-              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
-        {/*（相手からのメッセージ）*/}
-        <div className="chat-message">
-          <div className="flex items-end">
-            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
-              </div>
-            </div>
-            <img
-              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
-              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
-          </div>
-        </div>
-
+      <div
+        id="messages"
+        className="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch"
+      >
+        {chatMessages.map((value, index) => {
+          return (
+            value.role === 'user' ? <UserChatMessage name={value.name} message={value.message} avatarUrl={value.avatarUrl} key={index} /> : <CatChatMessage name={value.name} message={value.message} avatarUrl={value.avatarUrl} key={index} />
+          )
+        })}
       </div>
       <div className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
         <form id="send-message" method="post" action="" onSubmit={handleSubmit} aria-label="send to message">

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -14,41 +14,6 @@ type ChatMessage = {
 
 type ChatMessages = ChatMessage[];
 
-const chatMessages: ChatMessages = [
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-  { role: 'user', name: 'User', message: 'こんにちはもこちゃん！お話しよう！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp' },
-  { role: 'user', name: 'User', message: 'ねこちゃんはチュール好きな子多いけど、もこちゃんは好きじゃないんだね！', avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4' },
-  { role: 'cat', name: 'もこちゃん', message: 'そうにゃ🐱もこはウェットフードが苦手だにゃ🐱Userさんの好きな食べ物を教えてにゃー！', avatarUrl: 'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp'},
-];
-
 type Props = {
   chatMessages: ChatMessages;
 };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { FC, FormEvent } from 'react';
-import {Footer} from "@/components/Footer";
 import {UserChatMessage} from "@/components/UserChatMessage";
 import {CatChatMessage} from "@/components/CatChatMessage";
 
@@ -24,7 +23,7 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
   };
 
   return (
-    <div className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen bg-yellow-100">
+    <>
       <div className="flex sm:items-center justify-between py-3 border-b-2 border-amber-200 bg-yellow-200">
         <div className="relative flex items-center space-x-4">
           <div className="relative">
@@ -45,7 +44,7 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
       </div>
       <div
         id="messages"
-        className="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch"
+        className="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch bg-yellow-100"
       >
         {chatMessages.map((value, index) => {
           return (
@@ -53,7 +52,7 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
           )
         })}
       </div>
-      <div className="border-t-2 border-amber-200 px-4 pt-4 mb-2 sm:mb-0">
+      <div className="border-t-2 border-amber-200 px-4 pt-4 mb-2 sm:mb-0 bg-yellow-100">
         <form id="send-message" method="post" action="" onSubmit={handleSubmit} aria-label="send to message">
           <div className="relative flex">
           <textarea
@@ -73,7 +72,6 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
           </div>
         </form>
       </div>
-      <Footer />
-    </div>
+    </>
   );
 };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -59,8 +59,8 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
   };
 
   return (
-    <div className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen bg-white">
-      <div className="flex sm:items-center justify-between py-3 border-b-2 border-gray-200">
+    <div className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen bg-yellow-100">
+      <div className="flex sm:items-center justify-between py-3 border-b-2 border-amber-200 bg-yellow-200">
         <div className="relative flex items-center space-x-4">
           <div className="relative">
             <img
@@ -88,14 +88,14 @@ export const Chat: FC<Props> = ({ chatMessages }) => {
           )
         })}
       </div>
-      <div className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
+      <div className="border-t-2 border-amber-200 px-4 pt-4 mb-2 sm:mb-0">
         <form id="send-message" method="post" action="" onSubmit={handleSubmit} aria-label="send to message">
           <div className="relative flex">
           <textarea
             id="message-input"
             name="message-input"
             placeholder="Write your message!"
-            className="w-full focus:outline-none focus:placeholder-gray-400 text-gray-600 placeholder-gray-600 pl-4 bg-gray-200 rounded-md py-3"
+            className="w-full focus:outline-none focus:placeholder-gray-400 text-gray-600 placeholder-gray-600 pl-4  rounded-md py-3"
           />
           </div>
           <div className="flex flex-row-reverse mt-1">

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FC, FormEvent } from 'react';
+import {Footer} from "@/components/Footer";
 
 export const Chat: FC = () => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -54,25 +55,133 @@ export const Chat: FC = () => {
               alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
           </div>
         </div>
+
+        {/*（自分のメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end justify-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
+              </div>
+            </div>
+            <img
+              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（相手からのメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
+              </div>
+            </div>
+            <img
+              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（自分のメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end justify-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
+              </div>
+            </div>
+            <img
+              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（相手からのメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
+              </div>
+            </div>
+            <img
+              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（自分のメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end justify-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
+              </div>
+            </div>
+            <img
+              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（相手からのメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
+              </div>
+            </div>
+            <img
+              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（自分のメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end justify-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">こんにちはもこちゃん！お話しよう！</span>
+              </div>
+            </div>
+            <img
+              src="https://avatars.githubusercontent.com/u/11032365?s=96&v=4"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
+        {/*（相手からのメッセージ）*/}
+        <div className="chat-message">
+          <div className="flex items-end">
+            <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+              <div><span className="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">こんにちはにゃん🐱もことお話しようにゃん！もこはねこだけど、チュールは苦手だにゃ🐱チキン味のカリカリしか食べないにゃん！</span>
+              </div>
+            </div>
+            <img
+              src="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
+              alt="My profile" className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+          </div>
+        </div>
+
       </div>
-      <form id="send-message" method="post" action="" className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0" onSubmit={handleSubmit} aria-label="send to message">
-        <div className="relative flex">
+      <div className="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
+        <form id="send-message" method="post" action="" onSubmit={handleSubmit} aria-label="send to message">
+          <div className="relative flex">
           <textarea
             id="message-input"
             name="message-input"
             placeholder="Write your message!"
             className="w-full focus:outline-none focus:placeholder-gray-400 text-gray-600 placeholder-gray-600 pl-4 bg-gray-200 rounded-md py-3"
           />
-        </div>
-        <div className="flex flex-row-reverse mt-1">
-          <button
-            type="submit"
-            className="rounded-md bg-orange-500 px-4 py-3.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-          >
-            Send
-          </button>
-        </div>
-      </form>
+          </div>
+          <div className="flex flex-row-reverse mt-1">
+            <button
+              type="submit"
+              className="rounded-md bg-orange-500 px-4 py-3.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            >
+              Send
+            </button>
+          </div>
+        </form>
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/components/ChatContentLayout.tsx
+++ b/src/components/ChatContentLayout.tsx
@@ -1,0 +1,15 @@
+import type { FC, ReactNode } from 'react';
+import { Footer } from "@/components/Footer";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const ChatContentLayout: FC<Props> = ({ children }) => {
+  return (
+    <main className="flex-1 p:2 sm:p-6 justify-between flex flex-col h-screen bg-yellow-100">
+      {children}
+      <Footer />
+    </main>
+  );
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+export const Footer = () => {
+  return (
+    <footer className="bg-white rounded-lg shadow dark:bg-gray-900 m-4">
+      <div className="w-full max-w-screen-xl mx-auto p-4 md:py-8">
+        <div className="sm:flex sm:items-center sm:justify-between">
+          <Link href="/" className="flex items-center mb-4 sm:mb-0">
+            <span className="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">AI Cat（仮）</span>
+          </Link>
+          <ul className="flex flex-wrap items-center mb-6 text-sm font-medium text-gray-500 sm:mb-0 dark:text-gray-400">
+            <li>
+              <Link href="/terms" prefetch={false} className="mr-4 hover:underline md:mr-6">Terms of Use</Link>
+            </li>
+            <li>
+              <Link href="/privacy" prefetch={false} className="mr-4 hover:underline md:mr-6">Privacy Policy</Link>
+            </li>
+          </ul>
+        </div>
+        <hr className="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8"/>
+        <span className="block text-sm text-gray-500 sm:text-center dark:text-gray-400">Copyright (c) <a
+          href="https://github.com/nekochans" className="hover:underline">nekochans</a></span>
+      </div>
+    </footer>
+  )
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,13 +2,16 @@ import Link from 'next/link';
 
 export const Footer = () => {
   return (
-    <footer className="bg-white rounded-lg shadow dark:bg-gray-900 m-4">
+    <footer className="bg-yellow-200 rounded-lg shadow dark:bg-gray-900 m-4">
       <div className="w-full max-w-screen-xl mx-auto p-4 md:py-8">
         <div className="sm:flex sm:items-center sm:justify-between">
           <Link href="/" className="flex items-center mb-4 sm:mb-0">
             <span className="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">AI Cat（仮）</span>
           </Link>
           <ul className="flex flex-wrap items-center mb-6 text-sm font-medium text-gray-500 sm:mb-0 dark:text-gray-400">
+            <li>
+              <Link href="/" prefetch={false} className="mr-4 hover:underline md:mr-6">Top</Link>
+            </li>
             <li>
               <Link href="/terms" prefetch={false} className="mr-4 hover:underline md:mr-6">Terms of Use</Link>
             </li>
@@ -17,7 +20,7 @@ export const Footer = () => {
             </li>
           </ul>
         </div>
-        <hr className="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8"/>
+        <hr className="my-6 border-amber-200 sm:mx-auto dark:border-gray-700 lg:my-8"/>
         <span className="block text-sm text-gray-500 sm:text-center dark:text-gray-400">Copyright (c) <a
           href="https://github.com/nekochans" className="hover:underline">nekochans</a></span>
       </div>

--- a/src/components/UserChatMessage.tsx
+++ b/src/components/UserChatMessage.tsx
@@ -11,7 +11,7 @@ export const UserChatMessage: FC<Props> = ({ message, avatarUrl, name }) => {
     <div className="chat-message">
       <div className="flex items-end justify-end">
         <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-          <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-orange-200">{message}</span>
+          <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-amber-200">{message}</span>
           </div>
         </div>
         <img

--- a/src/components/UserChatMessage.tsx
+++ b/src/components/UserChatMessage.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+type Props = {
+  message: string;
+  avatarUrl: string;
+  name: string;
+};
+
+export const UserChatMessage: FC<Props> = ({ message, avatarUrl, name }) => {
+  return (
+    <div className="chat-message">
+      <div className="flex items-end justify-end">
+        <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+          <div><span className="px-4 py-2 rounded-lg inline-block rounded-br-none bg-orange-200">{message}</span>
+          </div>
+        </div>
+        <img
+          src={avatarUrl}
+          alt={name} className="w-10 sm:w-16 h-10 sm:h-16 rounded-full" />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/ai-cat-prototype/issues/5

# やった事
Chatページ用のLayoutを作成。

最初はHeaderとFooterを表示する予定だったが、Chat系のアプリを見ているとHeaderが設置されていないシンプルなLayoutが多かったのでFooterだけを追加する事にした。

ついでにデザインを黄色系のカラーに変更した。

<img width="639" alt="スクリーンショット 2023-05-11 0 03 26" src="https://github.com/keitakn/ai-cat-prototype/assets/11032365/5e300709-ce2d-4d57-b5f6-d2fa44b25947">
<img width="1239" alt="スクリーンショット 2023-05-10 18 19 03" src="https://github.com/keitakn/ai-cat-prototype/assets/11032365/f0162d59-3506-4096-80c2-37b46e222246">