### PR TITLE
実際にAPIサーバーと通信する機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -8,6 +8,9 @@ type RequestBody = {
 type ResponseBody = {
   message: string;
 };
+
+export const runtime = 'edge';
+
 export async function POST(request: Request): Promise<NextResponse> {
   const requestBody = (await request.json()) as RequestBody;
 
@@ -17,7 +20,9 @@ export async function POST(request: Request): Promise<NextResponse> {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Basic ${String(process.env.API_BASIC_AUTH_CREDENTIALS)}`,
+        Authorization: `Basic ${String(
+          process.env.API_BASIC_AUTH_CREDENTIALS
+        )}`,
       },
       body: JSON.stringify({ message: requestBody.message }),
     }

--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+type RequestBody = {
+  catName: string;
+  message: string;
+};
+
+type ResponseBody = {
+  message: string;
+};
+export async function POST(request: Request): Promise<NextResponse> {
+  const requestBody = (await request.json()) as RequestBody;
+
+  const response = await fetch(
+    `${String(process.env.API_BASE_URL)}/cats/${requestBody.catName}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${String(process.env.API_BASIC_AUTH_CREDENTIALS)}`,
+      },
+      body: JSON.stringify({ message: requestBody.message }),
+    }
+  );
+  const responseBody = (await response.json()) as ResponseBody;
+
+  return NextResponse.json(responseBody, { status: 201 });
+}

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -9,6 +9,10 @@ import {
 } from 'react';
 import { ChatMessagesList, type ChatMessages } from './ChatMessagesList';
 
+type ResponseBody = {
+  message: string;
+};
+
 type Props = {
   initChatMessages: ChatMessages;
 };
@@ -19,7 +23,7 @@ export const ChatContent: FC<Props> = ({ initChatMessages }) => {
 
   const ref = useRef<HTMLTextAreaElement>(null);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (ref.current?.value != null) {
@@ -36,6 +40,29 @@ export const ChatContent: FC<Props> = ({ initChatMessages }) => {
       const newChatMessages = [...chatMessages, ...[newUserMessage]];
 
       setChatMessages(newChatMessages);
+
+      const response = await fetch(`/api/cats`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ catName: 'moko', message }),
+      });
+      const body = (await response.json()) as ResponseBody;
+
+      const newCatMessage = {
+        role: 'cat',
+        name: 'もこちゃん',
+        message: body.message,
+        avatarUrl:
+          'https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp',
+      } as const;
+
+      const newCatReplyContainedChatMessage = [
+        ...newChatMessages,
+        ...[newCatMessage],
+      ];
+      setChatMessages(newCatReplyContainedChatMessage);
     }
   };
 


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/ai-cat-prototype/issues/9

# やった事
APIサーバーと通信を行い、実際にResponseを表示させるように変更。

APIをコールする部分のコードはまだ荒い部分があるので後でリファクタリングする。

以下のように応答までに少し時間がかかる。

https://github.com/keitakn/ai-cat-prototype/assets/11032365/6aed44ff-b298-46ed-97cc-336a1c7e60a8

その為、ローディングメッセージなどを表示させようかと思ったが今のUIだとローディングメッセージを出すとどうしても不自然な形になってしまう。

その為今後はバックエンドのAPI側で以下のようにストリーミングでResponseを返すようにする事を検討する必要がありそう。

https://note.com/mahlab/n/n14f1b1878d44