### PR TITLE
APIから応答が返ってくるまでの間の処理を追加

### DIFF
--- a/src/components/ChatContent/CatLoadingMessage.tsx
+++ b/src/components/ChatContent/CatLoadingMessage.tsx
@@ -11,7 +11,7 @@ export const CatLoadingMessage: FC<Props> = ({ avatarUrl, name }) => {
       <div className="order-2 mx-2 flex max-w-xs flex-col items-start space-y-2 text-xs">
         <div>
           <span className="inline-block animate-pulse rounded-lg rounded-bl-none bg-white px-4 py-2">
-            {name}ちゃんが入力中・・・🐱
+            {name}が入力中・・・🐱
           </span>
         </div>
       </div>

--- a/src/components/ChatContent/CatLoadingMessage.tsx
+++ b/src/components/ChatContent/CatLoadingMessage.tsx
@@ -1,0 +1,28 @@
+import type { FC } from 'react';
+import Image from 'next/image';
+
+type Props = {
+  avatarUrl: string;
+  name: string;
+};
+export const CatLoadingMessage: FC<Props> = ({ avatarUrl, name }) => {
+  return (
+    <div className="flex items-end">
+      <div className="order-2 mx-2 flex max-w-xs flex-col items-start space-y-2 text-xs">
+        <div>
+          <span className="inline-block animate-pulse rounded-lg rounded-bl-none bg-white px-4 py-2">
+            {name}ちゃんが入力中・・・🐱
+          </span>
+        </div>
+      </div>
+      <Image
+        src={avatarUrl}
+        // TODO width, heightの指定方法をどうするか後で考える
+        width={330}
+        height={400}
+        alt={name}
+        className="h-10 w-10 rounded-full sm:h-16 sm:w-16"
+      />
+    </div>
+  );
+};

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -96,6 +96,10 @@ export const ChatContent: FC<Props> = ({ initChatMessages }) => {
     }
   };
 
+  const submitButtonBgColor = isLoading ? 'bg-orange-300' : 'bg-orange-500';
+
+  const submitButtonHoverColor = isLoading ? 'hover:bg-orange-200' : 'hover:bg-orange-400';
+
   return (
     <>
       <ChatMessagesList chatMessages={chatMessages} isLoading={isLoading} />
@@ -120,7 +124,7 @@ export const ChatContent: FC<Props> = ({ initChatMessages }) => {
           <div className="mt-1 flex flex-row-reverse">
             <button
               type="submit"
-              className="rounded-md bg-orange-500 px-4 py-3.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              className={`${submitButtonBgColor} ${submitButtonHoverColor} rounded-md px-4 py-3.5 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600`}
               disabled={isLoading}
             >
               Send

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -98,7 +98,9 @@ export const ChatContent: FC<Props> = ({ initChatMessages }) => {
 
   const submitButtonBgColor = isLoading ? 'bg-orange-300' : 'bg-orange-500';
 
-  const submitButtonHoverColor = isLoading ? 'hover:bg-orange-200' : 'hover:bg-orange-400';
+  const submitButtonHoverColor = isLoading
+    ? 'hover:bg-orange-200'
+    : 'hover:bg-orange-400';
 
   return (
     <>

--- a/src/components/ChatContent/ChatMessagesList.tsx
+++ b/src/components/ChatContent/ChatMessagesList.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, type FC } from 'react';
 import { CatChatMessage } from '@/components/ChatContent/CatChatMessage';
+import { CatLoadingMessage } from '@/components/ChatContent/CatLoadingMessage';
 import { UserChatMessage } from '@/components/ChatContent/UserChatMessage';
 
 type ChatMessage = {
@@ -13,9 +14,10 @@ export type ChatMessages = ChatMessage[];
 
 type Props = {
   chatMessages: ChatMessages;
+  isLoading: boolean;
 };
 
-export const ChatMessagesList: FC<Props> = ({ chatMessages }) => {
+export const ChatMessagesList: FC<Props> = ({ chatMessages, isLoading }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -47,6 +49,14 @@ export const ChatMessagesList: FC<Props> = ({ chatMessages }) => {
           />
         );
       })}
+      {isLoading ? (
+        <CatLoadingMessage
+          name="もこちゃん"
+          avatarUrl="https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp"
+        />
+      ) : (
+        ''
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/ai-cat-prototype/issues/19

# やった事
以下のようにAPIから応答が返ってくる間はButtonを無効化して、ローディング用のメッセージを表示させるように変更。

https://github.com/keitakn/ai-cat-prototype/assets/11032365/8bbeddf2-641b-421a-8eb6-dd1fea70862d

元々ストリーミング形式にする予定だったが、以下のコメントにもあるようにLangChainのpredictメソッドがストリーミングに対応していないようなので、ストリーミングは利用しない事にした。

https://zenn.dev/link/comments/d2c9ca16ef27ec