### PR TITLE
設定が簡単でより並び替えをキレイに出来る prettier-plugin-sort-imports を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,51 +74,6 @@
         }
       }
     ],
-    "import/order": [
-      "error",
-      {
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          "parent",
-          "sibling",
-          "object",
-          "index"
-        ],
-        "pathGroups": [
-          {
-            "pattern": "{react,react-dom/**,react-router*}",
-            "group": "builtin",
-            "position": "before"
-          },
-          {
-            "pattern": "{routes/**,stores/**,utils/**,hooks/**,domains/**}",
-            "group": "internal",
-            "position": "after"
-          },
-          {
-            "pattern": "{A-Z]*,**/[A-Z]*}",
-            "group": "internal",
-            "position": "after"
-          },
-          {
-            "pattern": "assets/**}",
-            "group": "internal",
-            "position": "after"
-          },
-          {
-            "pattern": "./*.{css,scss,sass,less}",
-            "group": "index",
-            "position": "after"
-          }
-        ],
-        "pathGroupsExcludedImportTypes": ["builtin"],
-        "alphabetize": {
-          "order": "asc"
-        }
-      }
-    ],
     "react/display-name": "off"
   },
   "overrides": [

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "typescript": "5.0.4"
       },
       "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^4.1.1",
         "@types/eslint": "^8.37.0",
         "@types/jest": "^29.5.1",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
@@ -1458,6 +1459,95 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz",
+      "integrity": "sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4974,6 +5064,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "29.5.0",
@@ -9343,6 +9439,73 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@trivago/prettier-plugin-sort-imports": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz",
+      "integrity": "sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -11822,6 +11985,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "jest": {
       "version": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/eslint": "^8.37.0",
     "@types/jest": "^29.5.1",
     "@typescript-eslint/eslint-plugin": "^5.59.5",

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode, FC } from 'react';
 import type { Metadata } from 'next';
 import { Noto_Sans_JP } from 'next/font/google';
+import type { FC, ReactNode } from 'react';
 
 const font = Noto_Sans_JP({
   weight: '400',

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,5 +1,5 @@
-import type { NextPage } from 'next';
 import { ChatContent, ChatContentLayout } from '@/components';
+import type { NextPage } from 'next';
 
 const chatMessages = [
   {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
-import type { ReactNode, FC } from 'react';
 import type { Metadata } from 'next';
 import { Noto_Sans_JP } from 'next/font/google';
+import type { FC, ReactNode } from 'react';
 
 const font = Noto_Sans_JP({
   weight: '400',

--- a/src/components/ChatContent/CatChatMessage.tsx
+++ b/src/components/ChatContent/CatChatMessage.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
 import Image from 'next/image';
+import type { FC } from 'react';
 
 type Props = {
   message: string;

--- a/src/components/ChatContent/CatLoadingMessage.tsx
+++ b/src/components/ChatContent/CatLoadingMessage.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
 import Image from 'next/image';
+import type { FC } from 'react';
 
 type Props = {
   avatarUrl: string;

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -1,13 +1,13 @@
 'use client';
 
+import { type ChatMessages, ChatMessagesList } from './ChatMessagesList';
 import {
-  useRef,
-  useState,
   type FC,
   type FormEvent,
   type KeyboardEvent,
+  useRef,
+  useState,
 } from 'react';
-import { ChatMessagesList, type ChatMessages } from './ChatMessagesList';
 
 type ResponseBody = {
   message: string;

--- a/src/components/ChatContent/ChatContentLayout.tsx
+++ b/src/components/ChatContent/ChatContentLayout.tsx
@@ -1,6 +1,6 @@
-import type { FC, ReactNode } from 'react';
 import { ChatHeader } from '@/components/ChatContent/ChatHeader';
 import { Footer } from '@/components/Footer/';
+import type { FC, ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;

--- a/src/components/ChatContent/ChatHeader.tsx
+++ b/src/components/ChatContent/ChatHeader.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
 import Image from 'next/image';
+import type { FC } from 'react';
 
 export const ChatHeader: FC = () => {
   return (

--- a/src/components/ChatContent/ChatMessagesList.tsx
+++ b/src/components/ChatContent/ChatMessagesList.tsx
@@ -1,7 +1,7 @@
-import { useRef, useEffect, type FC } from 'react';
 import { CatChatMessage } from '@/components/ChatContent/CatChatMessage';
 import { CatLoadingMessage } from '@/components/ChatContent/CatLoadingMessage';
 import { UserChatMessage } from '@/components/ChatContent/UserChatMessage';
+import { type FC, useEffect, useRef } from 'react';
 
 type ChatMessage = {
   role: 'user' | 'cat';

--- a/src/components/ChatContent/UserChatMessage.tsx
+++ b/src/components/ChatContent/UserChatMessage.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
 import Image from 'next/image';
+import type { FC } from 'react';
 
 type Props = {
   message: string;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
 import Link from 'next/link';
+import type { FC } from 'react';
 
 export const Footer: FC = () => {
   return (


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/ai-cat-prototype/issues/18

# 内容

設定が簡単でより並び替えがキレイになる `prettier-plugin-sort-imports` を追加。

https://github.com/trivago/prettier-plugin-sort-imports

それに伴って `eslint-plugin-import` の並び替えルールを削除した。

ただし `import/extensions` のルールだけはPrettierではなくESLintがカバーすべき領域だと考え、残してある。

全てのファイルに対してFormatterを実行済。